### PR TITLE
chore: Bump versions

### DIFF
--- a/01_java_gradle_groovy/gradle.properties
+++ b/01_java_gradle_groovy/gradle.properties
@@ -19,5 +19,5 @@
 group=org.kordamp.sample
 version=0.0.0
 
-kordampVersion=0.45.0
-junitVersion=5.7.1
+kordampVersion=0.46.0
+junitVersion=5.7.2

--- a/02_java_gradle_kotlin_dsl/gradle.properties
+++ b/02_java_gradle_kotlin_dsl/gradle.properties
@@ -19,6 +19,6 @@
 group=org.kordamp.sample
 version=0.0.0
 
-kotlinVersion=1.4.31
-kordampVersion=0.45.0
-junitVersion=5.7.1
+kotlinVersion=1.5.10
+kordampVersion=0.46.0
+junitVersion=5.7.2

--- a/03_kotlin_gradle_kotlin_dsl/gradle.properties
+++ b/03_kotlin_gradle_kotlin_dsl/gradle.properties
@@ -19,6 +19,6 @@
 group=org.kordamp.sample
 version=0.0.0
 
-kotlinVersion=1.4.31
-kordampVersion=0.45.0
-junitVersion=5.7.1
+kotlinVersion=1.5.10
+kordampVersion=0.46.0
+junitVersion=5.7.2

--- a/04_license_reproducer/gradle.properties
+++ b/04_license_reproducer/gradle.properties
@@ -1,6 +1,6 @@
 group=org.kordamp.sample
 version=0.0.0
 
-kotlinVersion=1.4.31
-kordampVersion=0.45.0
-junitVersion=5.7.1
+kotlinVersion=1.5.10
+kordampVersion=0.46.0
+junitVersion=5.7.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* kordamp-gradle-plugin from 0.45.0 to 0.46.0
* gradle-wrapper form 6.8.3 to 6.9
* kotlin from 1.4.32 to 1.5.10
* junit5 from 5.7.1 to 5.7.2